### PR TITLE
update for ghc 8.6 monadfail changes

### DIFF
--- a/src/Verifier/SAW/Heapster/SAWTranslation.hs
+++ b/src/Verifier/SAW/Heapster/SAWTranslation.hs
@@ -38,6 +38,7 @@ import GHC.TypeLits
 import qualified Data.Functor.Constant as Constant
 import Control.Applicative
 import Control.Lens hiding ((:>),Index)
+import Control.Monad.Fail
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Cont
@@ -240,6 +241,9 @@ class TransInfo info where
 newtype TransM info (ctx :: RList CrucibleType) a =
   TransM { unTransM :: Reader (info ctx) a }
   deriving (Functor, Applicative, Monad)
+
+instance MonadFail (TransM info ctx) where
+  fail = error
 
 -- | The run function for the 'TransM' monad
 runTransM :: TransM info ctx a -> info ctx -> a


### PR DESCRIPTION
This gets Heapster building with GHC 8.6 by giving a trivial instance for `MonadFail`.  This essentially replicates the default behavior for prior versions of GHC.

We'll also need to bump the submodule in the saw-script repo.