### PR TITLE
Build against hobbits-1.4

### DIFF
--- a/heapster-saw.cabal
+++ b/heapster-saw.cabal
@@ -35,7 +35,7 @@ library
     vector,
     filepath,
     language-rust,
-    hobbits >= 1.3.2
+    hobbits ^>= 1.4,
   hs-source-dirs: src
   build-tool-depends:
     alex:alex,

--- a/src/Verifier/SAW/Heapster/Implication.hs
+++ b/src/Verifier/SAW/Heapster/Implication.hs
@@ -5901,7 +5901,7 @@ proveVarLLVMBlocks' x ps psubst mb_bps_in mb_ps = case mbMatch mb_bps_in of
       implSplitSwapConjsM x ps' 1 >>>
   
       -- Prove an existential around the memblock permission we proved
-       partialSubstForceM (mbMap2 (,)
+      partialSubstForceM (mbMap2 (,)
                           mb_bp mb_mb_sh) "proveVarLLVMBlock" >>>= \(bp,mb_sh) ->
       introExistsM x e (fmap (\sh -> ValPerm_LLVMBlock $
                                      bp { llvmBlockShape = sh }) mb_sh) >>>

--- a/src/Verifier/SAW/Heapster/RustTypes.hs
+++ b/src/Verifier/SAW/Heapster/RustTypes.hs
@@ -137,7 +137,7 @@ rustCtxOfNames tp =
 inRustCtx :: NuMatching a => RustCtx ctx -> RustConvM a ->
              RustConvM (Mb ctx a)
 inRustCtx ctx m =
-  mbM $ nuMulti ctx $ \ns ->
+  mbM $ nuMulti (RL.map (\_-> Proxy) ctx) $ \ns ->
   let ns_ctx =
         RL.toList $ RL.map2 (\n (Pair (Constant str) tp) ->
                               Constant (str, Some (Typed tp n))) ns ctx in
@@ -351,7 +351,8 @@ data ArgLayout where
 instance Semigroup ArgLayout where
   ArgLayout ghosts1 args1 mb_ps1 <> ArgLayout ghosts2 args2 mb_ps2 =
     ArgLayout (RL.append ghosts1 ghosts2) (RL.append args1 args2) $
-    mbCombine $ fmap (\ps1 -> fmap (\ps2 -> RL.append ps1 ps2) mb_ps2) mb_ps1
+    mbCombine (RL.mapRAssign (const Proxy) ghosts2) $
+    fmap (\ps1 -> fmap (\ps2 -> RL.append ps1 ps2) mb_ps2) mb_ps1
 
 instance Monoid ArgLayout where
   mempty = ArgLayout MNil MNil (emptyMb $ MNil)
@@ -365,8 +366,8 @@ argLayout1 p =
 -- additional ghost argument for the bound name
 mbArgLayout :: KnownRepr TypeRepr a => Binding a ArgLayout -> ArgLayout
 mbArgLayout (mbMatch -> [nuMP| ArgLayout ghosts args mb_ps |]) =
-  ArgLayout (mbLift ghosts :>: KnownReprObj) (mbLift args) (mbCombine $
-                                                            mbSwap mb_ps)
+  ArgLayout (mbLift ghosts :>: KnownReprObj) (mbLift args)
+            (mbCombine RL.typeCtxProxies (mbSwap (RL.mapRAssign (const Proxy) (mbLift ghosts)) mb_ps))
 
 -- | Convert an 'ArgLayout' to a permission on a @struct@ of its arguments
 argLayoutStructPerm :: ArgLayout -> Some (Typed ValuePerm)
@@ -433,18 +434,23 @@ funPerm3FromArgLayout (ArgLayout ghosts args mb_arg_perms) ret_tp ret_perm =
   let gs_args_prxs = RL.map (const Proxy) (RL.append ghosts args) in
   Some3FunPerm $ FunPerm (knownCtxToCruCtx ghosts) (knownCtxToCruCtx args)
   ret_tp
-  (extMbMulti args $
+  (extMbMulti (RL.map (\_ -> Proxy) args) $
    fmap (RL.append $ RL.map (const ValPerm_True) ghosts) mb_arg_perms)
   (nuMulti (gs_args_prxs :>: Proxy) $ const
    (RL.map (const ValPerm_True) gs_args_prxs :>: ret_perm))
 
 -- | Extend a name binding by adding a name in the middle
-extMbMiddle :: prx1 ctx1 -> RAssign prx2 ctx2 -> prxb b ->
-               Mb (ctx1 :++: ctx2) a ->
-               Mb (ctx1 :++: ((RNil :> b) :++: ctx2)) a
+extMbMiddle ::
+  forall prx1 ctx1 prx2 ctx2 prxb a b.
+  prx1 ctx1 -> RAssign prx2 ctx2 -> prxb b ->
+  Mb (ctx1 :++: ctx2) a ->
+  Mb (ctx1 :++: ((RNil :> b) :++: ctx2)) a
 extMbMiddle (_ :: prx1 ctx1) ctx2 (_ :: prxb b) mb_a =
-  mbCombine $ fmap (mbCombine . nu @_ @b . const) $
+  mbCombine (RL.append (MNil :>: (Proxy :: Proxy b)) pxys) $
+  fmap (mbCombine pxys . nu @_ @b . const) $
   mbSeparate @_ @ctx1 ctx2 mb_a
+  where
+    pxys = RL.mapRAssign (const Proxy) ctx2
 
 -- | Insert an object into the middle of an 'RAssign'
 rassignInsertMiddle :: prx1 ctx1 -> RAssign prx2 ctx2 -> f b ->
@@ -475,15 +481,22 @@ mbAssoc :: prx1 ctx1 -> RAssign prx2 ctx2 -> RAssign prx3 ctx3 ->
            Mb (ctx1 :++: (ctx2 :++: ctx3)) a ->
            Mb ((ctx1 :++: ctx2) :++: ctx3) a
 mbAssoc ctx1 ctx2 ctx3 mb_a =
-  mbCombine $ mbCombine $ fmap (mbSeparatePrx ctx2 ctx3) $
+  mbCombine (RL.mapRAssign (const Proxy) ctx3) $
+  mbCombine (RL.mapRAssign (const Proxy) ctx2) $
+  fmap (mbSeparatePrx ctx2 ctx3) $
   mbSeparatePrx ctx1 (RL.append (RL.map (const Proxy) ctx2)
                       (RL.map (const Proxy) ctx3)) mb_a
 
-mbCombineAssoc :: prx1 ctx1 -> prx2 ctx2 -> RAssign prx3 ctx3 ->
-                  Mb ctx1 (Mb (ctx2 :++: ctx3) a) ->
-                  Mb ((ctx1 :++: ctx2) :++: ctx3) a
-mbCombineAssoc _ ctx2 ctx3 =
-  mbCombine . mbCombine . fmap (mbSeparatePrx ctx2 ctx3)
+mbCombineAssoc ::
+  prx1 ctx1 ->
+  RAssign prx2 ctx2 ->
+  RAssign prx3 ctx3 ->
+  Mb ctx1 (Mb (ctx2 :++: ctx3) a) ->
+  Mb ((ctx1 :++: ctx2) :++: ctx3) a
+mbCombineAssoc _ ctx2 ctx3
+  = mbCombine (RL.mapRAssign (const Proxy) ctx3)
+  . mbCombine (RL.mapRAssign (const Proxy) ctx2)
+  . fmap (mbSeparatePrx ctx2 ctx3)
 
 assocAppend :: RAssign f ctx1 -> prx2 ctx2 -> RAssign prx3 ctx3 ->
                RAssign f (ctx2 :++: ctx3) ->
@@ -505,10 +518,12 @@ mbGhostsFunPerm3 new_ghosts (mbMatch -> [nuMP| Some3FunPerm
                           mbLift ghosts) (mbLift args) (mbLift ret)
   (mbAssoc new_prxs ghosts_prxs args_prxs $
    fmap (assocAppend (RL.map (const ValPerm_True) new_prxs)
-         ghosts_prxs args_prxs) $ mbCombine ps_in)
+         ghosts_prxs args_prxs) $
+         mbCombine (RL.append ghosts_prxs args_prxs) ps_in)
   (mbAssoc new_prxs ghosts_prxs (args_prxs :>: Proxy) $
    fmap (assocAppend (RL.map (const ValPerm_True) new_prxs)
-         ghosts_prxs (args_prxs :>: Proxy)) $ mbCombine ps_out)
+         ghosts_prxs (args_prxs :>: Proxy)) $
+         mbCombine (RL.append ghosts_prxs args_prxs :>: Proxy) ps_out)
 
 -- | Try to compute the layout of a structure of the given shape as a value,
 -- over 1 or more registers, if this is possible
@@ -656,7 +671,8 @@ instance Functor SomeTypedMb where
 instance Applicative SomeTypedMb where
   pure a = SomeTypedMb CruCtxNil $ emptyMb a
   liftA2 f (SomeTypedMb ctx1 mb_a1) (SomeTypedMb ctx2 mb_a2) =
-    SomeTypedMb (appendCruCtx ctx1 ctx2) $ mbCombine $
+    SomeTypedMb (appendCruCtx ctx1 ctx2) $
+    mbCombine (cruCtxProxies ctx2) $
     flip fmap mb_a1 $ \a1 -> flip fmap mb_a2 $ \a2 -> f a1 a2
 
 -- | Abstract over all the read/write and lifetime modalities in an
@@ -714,9 +730,6 @@ lownedPermsForLifetime l (_ :>: vap) =
 lifetimeDefName :: LifetimeDef a -> String
 lifetimeDefName (LifetimeDef _ (Lifetime name _) _ _) = name
 
-extMbOuter :: RAssign prx ctx1 -> Mb ctx2 a -> Mb (ctx1 :++: ctx2) a
-extMbOuter prxs mb_a = mbCombine $ nuMulti prxs $ const mb_a
-
 -- | Add a lifetime described by a 'LifetimeDef' to a 'Some3FunPerm'
 mbLifetimeFunPerm :: LifetimeDef Span -> Binding LifetimeType Some3FunPerm ->
                      RustConvM Some3FunPerm
@@ -727,10 +740,10 @@ mbLifetimeFunPerm (LifetimeDef _ _ [] _)
      let args_prxs = cruCtxProxies args
      let ret = mbLift $ fmap funPermRet fun_perm
      let mb_ps_in =
-           mbCombineAssoc (MNil :>: Proxy) ghosts args_prxs $
+           mbCombineAssoc (MNil :>: Proxy) (cruCtxProxies ghosts) args_prxs $
            fmap (mbValuePermsToDistPerms . funPermIns) fun_perm
      let mb_ps_out =
-           mbCombineAssoc (MNil :>: Proxy) ghosts (args_prxs :>: Proxy) $
+           mbCombineAssoc (MNil :>: Proxy) (cruCtxProxies ghosts) (args_prxs :>: Proxy) $
            fmap (mbValuePermsToDistPerms . funPermOuts) fun_perm
      let mb_l =
            extMbMulti (cruCtxProxies args) $

--- a/src/Verifier/SAW/Heapster/SAWTranslation.hs
+++ b/src/Verifier/SAW/Heapster/SAWTranslation.hs
@@ -2991,8 +2991,8 @@ translatePermImplUnary ::
   Mb ctx (MbPermImpls r (RNil :> '(bs,ps_out))) ->
   (ImpTransM ext blocks tops ret ps_out (ctx :++: bs) OpenTerm ->
    ImpTransM ext blocks tops ret ps ctx OpenTerm) ->
-  PermImplTransM (ImplFailCont ->
-  ImpTransM ext blocks tops ret ps ctx OpenTerm)
+  PermImplTransM
+    (ImplFailCont -> ImpTransM ext blocks tops ret ps ctx OpenTerm)
 translatePermImplUnary (mbMatch -> [nuMP| MbPermImpls_Cons _ _ mb_impl |]) f =
   translatePermImpl Proxy (mbCombine RL.typeCtxProxies mb_impl) >>= \trans ->
   return $ \k -> f $ trans k

--- a/src/Verifier/SAW/Heapster/SAWTranslation.hs
+++ b/src/Verifier/SAW/Heapster/SAWTranslation.hs
@@ -323,7 +323,7 @@ nuMultiTransM :: TransInfo info => (RAssign Name ctx -> b) ->
                  TransM info ctx (Mb ctx b)
 nuMultiTransM f =
   do info <- ask
-     return $ nuMulti (infoCtx info) f
+     return $ nuMulti (RL.map (\_ -> Proxy) (infoCtx info)) f
 
 -- | Apply the result of a translation to that of another
 applyTransM :: TransM info ctx OpenTerm -> TransM info ctx OpenTerm ->
@@ -801,7 +801,7 @@ instance TransInfo info =>
     [nuMP| PExpr_ExShape mb_sh |] ->
       do tp_trans <- translate $ fmap bindingType mb_sh
          tp_f_trm <- lambdaTupleTransM "x_exsh" tp_trans $ \e ->
-           transTupleTerm <$> inExtTransM e (translate $ mbCombine mb_sh)
+           transTupleTerm <$> inExtTransM e (translate $ mbCombine RL.typeCtxProxies mb_sh)
          return $ ETrans_Term (dataTypeOpenTerm "Prelude.Sigma"
                                [typeTransTupleType tp_trans, tp_f_trm])
 
@@ -1066,7 +1066,7 @@ eqPermTransCtx :: forall (ctx :: RList CrucibleType) (ps :: RList CrucibleType) 
                   RAssign any ctx -> RAssign (Member ctx) ps ->
                   PermTransCtx ctx ps
 eqPermTransCtx ns =
-  RL.map (\memb -> PTrans_Eq $ nuMulti ns (PExpr_Var . RL.get memb))
+  RL.map (\memb -> PTrans_Eq $ nuMulti (RL.map (\_-> Proxy) ns) (PExpr_Var . RL.get memb))
 
 
 instance IsTermTrans (PermTrans ctx a) where
@@ -1174,7 +1174,9 @@ permTransPermEq ptrans mb_p =
 
 
 extsMb :: CruCtx ctx2 -> Mb ctx a -> Mb (ctx :++: ctx2) a
-extsMb ctx = mbCombine . fmap (nus (cruCtxProxies ctx) . const)
+extsMb ctx = mbCombine proxies . fmap (nus proxies . const)
+  where
+    proxies = cruCtxProxies ctx
 
 -- | Generic function to extend the context of the translation of a permission
 class ExtPermTrans f where
@@ -1556,7 +1558,7 @@ instance TransInfo info =>
          tp_trans <- translateClosed tp
          mkPermTypeTrans1 p <$>
            sigmaTypeTransM "x_ex" tp_trans (\x -> inExtTransM x $
-                                                  translate $ mbCombine p1)
+                                                  translate $ mbCombine RL.typeCtxProxies p1)
     [nuMP| ValPerm_Named npn args off |] ->
       do env <- infoEnv <$> ask
          args_trans <- translate args
@@ -1713,10 +1715,12 @@ instance TransInfo info =>
 instance TransInfo info =>
          Translate info ctx (FunPerm ghosts args ret) OpenTerm where
   translate (mbMatch -> [nuMP| FunPerm ghosts args ret perms_in perms_out |]) =
-    piExprCtx (appendCruCtx (mbLift ghosts) (mbLift args)) $
-    piPermCtx (mbCombine perms_in) $ \_ ->
+    let ctx = appendCruCtx (mbLift ghosts) (mbLift args)
+        pxys = cruCtxProxies ctx in
+    piExprCtx ctx $
+    piPermCtx (mbCombine pxys perms_in) $ \_ ->
     applyTransM (return $ globalOpenTerm "Prelude.CompM") $
-    translateRetType (mbLift ret) $ mbCombine perms_out
+    translateRetType (mbLift ret) $ mbCombine (pxys :>: Proxy) perms_out
 
 -- | Lambda-abstraction over a permission
 lambdaPermTrans :: TransInfo info => String -> Mb ctx (ValuePerm a) ->
@@ -2071,7 +2075,7 @@ translateSimplImpl (ps0 :: Proxy ps0) mb_simpl m = case mbMatch mb_simpl of
        tp_trans <- translateClosed tp
        etrans <- translate e
        sigma_trm <-
-         sigmaTransM "x_ex" tp_trans (flip inExtTransM $ translate $ mbCombine p)
+         sigmaTransM "x_ex" tp_trans (flip inExtTransM $ translate $ mbCombine RL.typeCtxProxies p)
          etrans getTopPermM
        withPermStackM id
          ((:>: PTrans_Term (fmap ValPerm_Exists p) sigma_trm) . RL.tail)
@@ -2982,14 +2986,15 @@ implTransAltErr str (ImplFailContMsg _) =
 -- translation function if the argument succeeds and fails if the translation of
 -- the argument fails
 translatePermImplUnary ::
+  RL.TypeCtx bs =>
   ImplTranslateF r ext blocks tops ret =>
   Mb ctx (MbPermImpls r (RNil :> '(bs,ps_out))) ->
   (ImpTransM ext blocks tops ret ps_out (ctx :++: bs) OpenTerm ->
    ImpTransM ext blocks tops ret ps ctx OpenTerm) ->
   PermImplTransM (ImplFailCont ->
-                  ImpTransM ext blocks tops ret ps ctx OpenTerm)
-translatePermImplUnary (mbMatch -> [nuMP| MbPermImpls_Cons _ mb_impl |]) f =
-  translatePermImpl Proxy (mbCombine mb_impl) >>= \trans ->
+  ImpTransM ext blocks tops ret ps ctx OpenTerm)
+translatePermImplUnary (mbMatch -> [nuMP| MbPermImpls_Cons _ _ mb_impl |]) f =
+  translatePermImpl Proxy (mbCombine RL.typeCtxProxies mb_impl) >>= \trans ->
   return $ \k -> f $ trans k
 
 
@@ -3008,9 +3013,9 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
     tell [mbLift str] >> mzero
   
   ([nuMP| Impl1_Catch |],
-   [nuMP| (MbPermImpls_Cons (MbPermImpls_Cons _ mb_impl1) mb_impl2) |]) ->
-    pitmCatching (translatePermImpl prx $ mbCombine mb_impl1) >>= \maybe_trans1 ->
-    pitmCatching (translatePermImpl prx $ mbCombine mb_impl2) >>= \maybe_trans2 ->
+   [nuMP| (MbPermImpls_Cons _ (MbPermImpls_Cons _ _ mb_impl1) mb_impl2) |]) ->
+    pitmCatching (translatePermImpl prx $ mbCombine RL.typeCtxProxies mb_impl1) >>= \maybe_trans1 ->
+    pitmCatching (translatePermImpl prx $ mbCombine RL.typeCtxProxies mb_impl2) >>= \maybe_trans2 ->
     case (maybe_trans1, maybe_trans2) of
       (Just trans1, Just trans2) ->
         return $ \k ->
@@ -3040,9 +3045,9 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   -- If both branches of an or elimination fail, the whole thing fails; otherwise,
   -- an or elimination performs a pattern-match on an Either
   ([nuMP| Impl1_ElimOr x p1 p2 |],
-   [nuMP| (MbPermImpls_Cons (MbPermImpls_Cons _ mb_impl1) mb_impl2) |]) ->
-    pitmCatching (translatePermImpl prx $ mbCombine mb_impl1) >>= \maybe_trans1 ->
-    pitmCatching (translatePermImpl prx $ mbCombine mb_impl2) >>= \maybe_trans2 ->
+   [nuMP| (MbPermImpls_Cons _ (MbPermImpls_Cons _ _ mb_impl1) mb_impl2) |]) ->
+    pitmCatching (translatePermImpl prx $ mbCombine RL.typeCtxProxies mb_impl1) >>= \maybe_trans1 ->
+    pitmCatching (translatePermImpl prx $ mbCombine RL.typeCtxProxies mb_impl2) >>= \maybe_trans2 ->
     case (maybe_trans1, maybe_trans2) of
       (Nothing, Nothing) -> mzero
       _ ->
@@ -3069,7 +3074,7 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
        top_ptrans <- getTopPermM
        tp_trans <- translateClosed tp
        sigmaElimTransM "x_elimEx" tp_trans
-         (flip inExtTransM $ translate $ mbCombine p)
+         (flip inExtTransM $ translate $ mbCombine RL.typeCtxProxies p)
          compReturnTypeTransM
          (\etrans ptrans ->
            inExtTransM etrans $
@@ -3098,7 +3103,7 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
        let etrans_y = case etrans_x of
              ETrans_Struct flds -> RL.get (mbLift memb) flds
              _ -> error "translatePermImpl1: Impl1_ElimStructField"
-       let mb_y = mbCombine $ fmap (const $ nu $ \y -> PExpr_Var y) x
+       let mb_y = mbCombine RL.typeCtxProxies $ fmap (const $ nu $ \y -> PExpr_Var y) x
        inExtTransM etrans_y $
          withPermStackM (:>: Member_Base)
          (\(pctx :>: PTrans_Conj [APTrans_Struct pctx_str]) ->
@@ -3116,12 +3121,12 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
             unPTransLLVMField "translatePermImpl1: Impl1_ElimLLVMFieldContents"
             knownNat ptrans_x in
       pctx :>: PTrans_Conj [APTrans_LLVMField
-                            (mbCombine $
+                            (mbCombine RL.typeCtxProxies $
                              fmap (\fld -> nu $ \y ->
                                     fld { llvmFieldContents =
                                             ValPerm_Eq (PExpr_Var y)})
                              mb_fld) $
-                            PTrans_Eq (mbCombine $
+                            PTrans_Eq (mbCombine RL.typeCtxProxies $
                                        fmap (const $ nu PExpr_Var) mb_fld)]
       :>: ptrans')
     m
@@ -3177,8 +3182,8 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   -- implTransAltErr, not the entire type-checking error message, because this is
   -- considered just an assertion and not a failure
   ([nuMP| Impl1_TryProveBVProp x prop@(BVProp_Eq e1 e2) prop_str |],
-   [nuMP| MbPermImpls_Cons _ mb_impl' |]) ->
-    translatePermImpl prx (mbCombine mb_impl') >>= \trans ->
+   [nuMP| MbPermImpls_Cons _ _ mb_impl' |]) ->
+    translatePermImpl prx (mbCombine RL.typeCtxProxies mb_impl') >>= \trans ->
     return $ \k ->
     do prop_tp_trans <- translate prop
        applyMultiTransM (return $ globalOpenTerm "Prelude.maybe")
@@ -3193,8 +3198,8 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   
   -- For an inequality test, we don't need a proof, so just insert an if
   ([nuMP| Impl1_TryProveBVProp x prop@(BVProp_Neq e1 e2) prop_str |],
-   [nuMP| MbPermImpls_Cons _ mb_impl' |]) ->
-    translatePermImpl prx (mbCombine mb_impl') >>= \trans ->
+   [nuMP| MbPermImpls_Cons _ _ mb_impl' |]) ->
+    translatePermImpl prx (mbCombine RL.typeCtxProxies mb_impl') >>= \trans ->
     return $ \k ->
     let w = natVal2 prop in
     applyMultiTransM (return $ globalOpenTerm "Prelude.ite")
@@ -3218,8 +3223,8 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   -}
   
   ([nuMP| Impl1_TryProveBVProp x prop@(BVProp_ULt e1 e2) prop_str |],
-   [nuMP| MbPermImpls_Cons _ mb_impl' |]) ->
-    translatePermImpl prx (mbCombine mb_impl') >>= \trans ->
+   [nuMP| MbPermImpls_Cons _ _ mb_impl' |]) ->
+    translatePermImpl prx (mbCombine RL.typeCtxProxies mb_impl') >>= \trans ->
     return $ \k ->
     do prop_tp_trans <- translate prop
        applyMultiTransM (return $ globalOpenTerm "Prelude.maybe")
@@ -3245,8 +3250,8 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   -}
   
   ([nuMP| Impl1_TryProveBVProp x prop@(BVProp_ULeq e1 e2) prop_str |],
-   [nuMP| MbPermImpls_Cons _ mb_impl' |]) ->
-    translatePermImpl prx (mbCombine mb_impl') >>= \trans ->
+   [nuMP| MbPermImpls_Cons _ _ mb_impl' |]) ->
+    translatePermImpl prx (mbCombine RL.typeCtxProxies mb_impl') >>= \trans ->
     return $ \k ->
     do prop_tp_trans <- translate prop
        applyMultiTransM (return $ globalOpenTerm "Prelude.maybe")
@@ -3262,8 +3267,8 @@ translatePermImpl1 prx mb_impl mb_impls = case (mbMatch mb_impl, mbMatch mb_impl
   
   
   ([nuMP| Impl1_TryProveBVProp x prop@(BVProp_ULeq_Diff e1 e2 e3) prop_str |],
-   [nuMP| MbPermImpls_Cons _ mb_impl' |]) ->
-    translatePermImpl prx (mbCombine mb_impl') >>= \trans ->
+   [nuMP| MbPermImpls_Cons _ _ mb_impl' |]) ->
+    translatePermImpl prx (mbCombine RL.typeCtxProxies mb_impl') >>= \trans ->
     return $ \k ->
     do prop_tp_trans <- translate prop
        applyMultiTransM (return $ globalOpenTerm "Prelude.maybe")
@@ -3724,7 +3729,8 @@ translateStmt loc mb_stmt m = case mbMatch mb_stmt of
              PTrans_Conj [APTrans_Fun _ f_trm] -> f_trm
              _ -> error "translateStmt: TypedCall: unexpected function permission"
        -- let perms_in = fmap (distPermsSnoc . typedStmtIn) stmt
-       let perms_out = mbCombine $ fmap (\stmt' -> nu $ \ret ->
+       let perms_out = mbCombine RL.typeCtxProxies
+                     $ fmap (\stmt' -> nu $ \ret ->
                                           typedStmtOut stmt' (MNil :>: ret)) stmt
        ret_tp <- translate $ fmap funPermRet fun_perm
        ectx_gexprs <- translate gexprs
@@ -3811,11 +3817,11 @@ translateLLVMStmt mb_stmt m = case mbMatch mb_stmt of
             (knownNat @sz) p_ptr in
       RL.append
       (pctx :>: PTrans_Conj [APTrans_LLVMField
-                             (mbCombine $
+                             (mbCombine RL.typeCtxProxies $
                               fmap (\fp -> nu $ \ret ->
                                      fp { llvmFieldContents =
                                             ValPerm_Eq (PExpr_Var ret)}) mb_fp)
-                             (PTrans_Eq $ mbCombine $
+                             (PTrans_Eq $ mbCombine RL.typeCtxProxies $
                               fmap (const $ nu $ \ret -> PExpr_Var ret) mb_fp)]
        :>: p_ret) pctx_l)
     m
@@ -3887,7 +3893,7 @@ translateLLVMStmt mb_stmt m = case mbMatch mb_stmt of
     inExtTransM ETrans_LLVM $
     do b <- translate1 $ extMb mb_r1
        tptrans <-
-         translate $ mbCombine $ flip fmap mb_stmt $ \stmt -> nu $ \ret ->
+         translate $ mbCombine RL.typeCtxProxies $ flip fmap mb_stmt $ \stmt -> nu $ \ret ->
          distPermsHeadPerm $ typedLLVMStmtOut stmt ret
        let t = applyOpenTerm (globalOpenTerm "Prelude.boolToEither") b
        withPermStackM (:>: Member_Base) (:>: typeTransF tptrans [t]) m
@@ -3911,7 +3917,7 @@ instance PermCheckExtC ext =>
        ret_tp <- returnTypeM
        sigma_trm <-
          sigmaTransM "r" tp_trans (flip inExtTransM $
-                                   translate $ mbCombine mb_perms)
+                                   translate $ mbCombine RL.typeCtxProxies mb_perms)
          r_trans (itiPermStack <$> ask)
        return $
          applyOpenTermMulti (globalOpenTerm "Prelude.returnM")
@@ -3942,8 +3948,8 @@ instance PermCheckExtC ext =>
          (TypedStmtSeq ext blocks tops ret ps) OpenTerm where
   translate mb_x = case mbMatch mb_x of
     [nuMP| TypedImplStmt impl_seq |] -> translate impl_seq
-    [nuMP| TypedConsStmt loc stmt mb_seq |] ->
-      translateStmt (mbLift loc) stmt (translate $ mbCombine mb_seq)
+    [nuMP| TypedConsStmt loc stmt pxys mb_seq |] ->
+      translateStmt (mbLift loc) stmt (translate $ mbCombine (mbLift pxys) mb_seq)
     [nuMP| TypedTermStmt _ term_stmt |] -> translate term_stmt
 
 instance PermCheckExtC ext =>
@@ -4126,7 +4132,7 @@ translateCFG env (cfg :: TypedCFG ext blocks ghosts inits ret) =
                all_pctx = RL.append pctx inits_eq_perms in
            impTransM all_membs all_pctx mapTrans retTypeTrans $
            translateCallEntryID "CFG" (tpcfgEntryBlockID cfg) Proxy
-           (nuMulti all_pctx $ \_ -> PExprs_Nil)
+           (nuMulti (RL.map (\_-> Proxy) all_pctx) $ \_ -> PExprs_Nil)
            (mbValuePermsToDistPerms $ funPermToBlockInputs fun_perm)
          )
        ]
@@ -4293,7 +4299,7 @@ translateCompleteTypeInCtx :: SharedContext -> PermEnv ->
 translateCompleteTypeInCtx sc env args ret =
   completeOpenTerm sc $
   runNilTypeTransM (piExprCtx args (typeTransType1 <$> translate ret')) env
-  where ret' = mbCombine . emptyMb $ ret
+  where ret' = mbCombine (cruCtxProxies args) . emptyMb $ ret
 
 -- | Translate an input list of 'ValuePerms' and an output 'ValuePerm' to a SAW
 -- core function type in a manner similar to 'translateCompleteFunPerm', except
@@ -4307,5 +4313,6 @@ translateCompletePureFun sc env ctx args ret =
   completeOpenTerm sc $
   runNilTypeTransM (piExprCtx ctx $ piPermCtx args' $ const $
                     typeTransTupleType <$> translate ret') env
-  where args' = mbCombine . emptyMb $ args
-        ret'  = mbCombine . emptyMb $ ret
+  where args' = mbCombine pxys . emptyMb $ args
+        ret'  = mbCombine pxys . emptyMb $ ret
+        pxys  = cruCtxProxies ctx

--- a/src/Verifier/SAW/Heapster/TypedCrucible.hs
+++ b/src/Verifier/SAW/Heapster/TypedCrucible.hs
@@ -31,6 +31,7 @@ import qualified Data.Text as Text
 import Data.List (findIndex)
 import Data.Type.Equality
 import Data.Kind
+import Data.Reflection
 import qualified Data.BitVector.Sized as BV
 import GHC.TypeLits
 
@@ -601,6 +602,7 @@ data TypedStmtSeq ext blocks tops ret ps_in where
   -- value(s) of each statement
   TypedConsStmt :: !ProgramLoc ->
                    !(TypedStmt ext rets ps_in ps_next) ->
+                   !(RAssign Proxy rets) ->
                    !(Mb rets (TypedStmtSeq ext blocks tops ret ps_next)) ->
                    TypedStmtSeq ext blocks tops ret ps_in
 
@@ -862,10 +864,11 @@ instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
   genSubst s mb_x = case mbMatch mb_x of
     [nuMP| TypedImplStmt impl_seq |] ->
       TypedImplStmt <$> genSubst s impl_seq
-    [nuMP| TypedConsStmt loc stmt mb_seq |] ->
-      TypedConsStmt (mbLift loc) <$> genSubst s stmt <*> genSubst s mb_seq
+    [nuMP| TypedConsStmt loc stmt pxys mb_seq |] ->
+      TypedConsStmt (mbLift loc) <$> genSubst s stmt <*> pure (mbLift pxys) <*> give (mbLift pxys) (genSubst s mb_seq)
     [nuMP| TypedTermStmt loc term_stmt |] ->
       TypedTermStmt (mbLift loc) <$> genSubst s term_stmt
+
 
 instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
          Substable1 PermVarSubst (TypedStmtSeq ext blocks tops ret) m where
@@ -2074,7 +2077,7 @@ emitStmt :: CruCtx rets -> ProgramLoc ->
             (RAssign Name rets)
 emitStmt tps loc stmt =
   gopenBinding
-  ((TypedConsStmt loc stmt <$>) . strongMbM)
+  ((TypedConsStmt loc stmt (cruCtxProxies tps) <$>) . strongMbM)
   (mbPure (cruCtxProxies tps) ()) >>>= \(ns, ()) ->
   setVarTypes "x" ns tps >>>
   gmodify (modifySTCurPerms $ applyTypedStmt stmt ns) >>>
@@ -3117,6 +3120,7 @@ tcJumpTarget ctx (JumpTarget blkID args_tps args) =
       let ghosts = entryGhosts entryID
           ghosts_prxs = cruCtxProxies ghosts
           ex_perms =
+            give ghosts_prxs $
             varSubst (permVarSubstOfNames tops_args_ns) $
             mbSeparate ghosts_prxs $
             mbValuePermsToDistPerms entry_perms_in in
@@ -3337,7 +3341,7 @@ tcBlockEntry in_deg blk (BlockEntryInfo {..}) =
   let args_prxs = cruCtxProxies entryInfoArgs
       ghosts_prxs = cruCtxProxies $ entryGhosts entryInfoID
       ret_perms =
-        mbCombine $ extMbMulti ghosts_prxs $ extMbMulti args_prxs $
+        mbCombine RL.typeCtxProxies  $ extMbMulti ghosts_prxs $ extMbMulti args_prxs $
         mbSeparate (MNil :>: Proxy) stRetPerms in
   fmap (TypedEntry entryInfoID (addInDegrees in_deg entryInfoInDegree)
         stTopCtx entryInfoArgs stRetType entryInfoPermsIn ret_perms) $


### PR DESCRIPTION
This change takes advantage of the performance enhancements available in hobbits 1.4.

There should be no functionality changes other than to more carefully pass around proxies where needed to hobbits instead of leaving hobbits to recompute them.